### PR TITLE
Split Features performance improvement

### DIFF
--- a/tools/dtsplitfeature.py
+++ b/tools/dtsplitfeature.py
@@ -60,6 +60,7 @@ class DtSplitFeature(DtSingleEditTool):
         featuresToKeep = {} # store geoms that will stay with their id as key
         featuresToSplit = {}
         topoGeoms = [] # store all new geometries in this array
+        topoEditEnabled = QgsProject.instance().topologicalEditing()
 
         for aFeat in self.editLayer.getFeatures(QgsFeatureRequest(splitGeom.boundingBox())):
             anId = aFeat.id()
@@ -96,7 +97,7 @@ class DtSplitFeature(DtSingleEditTool):
 
             for thisGeom in geomsToSplit:
                 try:
-                    result,  newGeometries,  topoTestPoints = thisGeom.splitGeometry(splitterPList,  False)
+                    result,  newGeometries,  topoTestPoints = thisGeom.splitGeometry(splitterPList,  topoEditEnabled)
                 except:
                     self.iface.messageBar().pushCritical(title,
                         dtutils.dtGetErrorMessage() + QtCore.QCoreApplication.translate(
@@ -168,9 +169,8 @@ class DtSplitFeature(DtSingleEditTool):
         if len(featuresToAdd) > 0:
             if self.editLayer.addFeatures(featuresToAdd):
 
-                if QgsProject.instance().topologicalEditing():
-                    for aGeom in topoGeoms:
-                        self.editLayer.addTopologicalPoints(aGeom)
+                for pt in topoTestPoints:
+                    self.editLayer.addTopologicalPoints(pt)
 
                 self.editLayer.endEditCommand()
             else:

--- a/tools/dtsplitfeature.py
+++ b/tools/dtsplitfeature.py
@@ -59,7 +59,6 @@ class DtSplitFeature(DtSingleEditTool):
         featuresToAdd = [] # store new features in this array
         featuresToKeep = {} # store geoms that will stay with their id as key
         featuresToSplit = {}
-        topoGeoms = [] # store all new geometries in this array
         topoEditEnabled = QgsProject.instance().topologicalEditing()
         topoTestPointsAll = [] # store all topoTestPoints for all parts
 
@@ -159,11 +158,9 @@ class DtSplitFeature(DtSingleEditTool):
 
                 newFeatures = dtutils.dtMakeFeaturesFromGeometries(self.editLayer,  aFeat,  newGeoms)
                 featuresToAdd = featuresToAdd + newFeatures
-                topoGeoms = topoGeoms + newGeoms
 
             aFeat.setGeometry(keepGeom)
             featuresToKeep[anId] = aFeat
-            topoGeoms.append(keepGeom)
 
         for anId,  aFeat in list(featuresToKeep.items()):
             aGeom = aFeat.geometry()

--- a/tools/dtsplitfeature.py
+++ b/tools/dtsplitfeature.py
@@ -61,6 +61,7 @@ class DtSplitFeature(DtSingleEditTool):
         featuresToSplit = {}
         topoGeoms = [] # store all new geometries in this array
         topoEditEnabled = QgsProject.instance().topologicalEditing()
+        topoTestPointsAll = [] # store all topoTestPoints for all parts
 
         for aFeat in self.editLayer.getFeatures(QgsFeatureRequest(splitGeom.boundingBox())):
             anId = aFeat.id()
@@ -103,6 +104,8 @@ class DtSplitFeature(DtSingleEditTool):
                         dtutils.dtGetErrorMessage() + QtCore.QCoreApplication.translate(
                             "digitizingtools", "splitting of feature") + " " + str(aFeat.id()))
                     return None
+
+                topoTestPointsAll.append(topoTestPoints)
 
                 if result == 0: # success
                     if len(newGeometries) > 0:
@@ -169,8 +172,9 @@ class DtSplitFeature(DtSingleEditTool):
         if len(featuresToAdd) > 0:
             if self.editLayer.addFeatures(featuresToAdd):
 
-                for pt in topoTestPoints:
-                    self.editLayer.addTopologicalPoints(pt)
+                for topoTestPoint in topoTestPointsAll:
+                    for pt in topoTestPoint:
+                        self.editLayer.addTopologicalPoints(pt)
 
                 self.editLayer.endEditCommand()
             else:


### PR DESCRIPTION
Using the topologyTestPoints returned by splitGeometry instead of the
new geometries themselves dramatically speeds up the process of
splitting large polygons in large layers.

Tests showed performance increases by a factor of 200
(60 MB Shapefile, Polygon with 3900 vertices).